### PR TITLE
[build] Add Java CI with Maven

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,35 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '17.0.7'
+          distribution: 'graalvm' # See 'Options' for all available distributions
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: 'maven'
+          check-for-updates: 'true'
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    #- name: Update dependency graph
+    #  uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
## Pull Request

### Description
This pull request adds a new Java CI pipeline using Maven for the project. The pipeline is triggered on push and pull requests to the "master" branch. It sets up GraalVM with Java 17, caches Maven dependencies, and builds the project using the "mvn -B package" command. This addition improves the development process by automating the build process and ensuring compatibility with the latest JDK and Maven dependencies.

### Related Issue(s)
None

### Changes Made
- Added a new CI pipeline in the project's GitHub Actions workflow YAML file.
- Configured the pipeline to use JDK 17 with GraalVM and Maven as the build tool.
- Specified the "pom.xml" file for the Maven build process.

### Testing Done
To validate the changes, I performed the following tests:
- Executed the pipeline on a local development environment to verify the workflow setup.
- Triggered the pipeline by pushing changes to the "master" branch and observed successful builds on GitHub Actions.
- Created a pull request and confirmed that the pipeline runs and completes without errors.

### Screenshots (if applicable)
N/A

### Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [x] The changes have been tested thoroughly.
- [ ] Documentation has been updated, if necessary. (Documentation update is not applicable for this specific change.)
- [x] All tests pass successfully.
- [x] There are no unresolved merge conflicts.
- [x] The commit history is clean and focused.

### Additional Notes
The addition of this CI pipeline streamlines the development process and ensures the project is built consistently using the specified Java version and Maven configuration. This enhancement aligns with the project's goal of maintaining a robust and automated development workflow. Reviewers are welcome to provide feedback and suggestions to further improve the pipeline's efficiency and effectiveness.