### PR TITLE
[docs] Add GitHub release template

### DIFF
--- a/docs/git/release-template.md
+++ b/docs/git/release-template.md
@@ -1,0 +1,65 @@
+# Release Notes - [Release Version]
+
+## Release Date: [YYYY-MM-DD]
+
+### New Features
+
+- [Feature 1]
+- [Feature 2]
+- [Feature 3]
+
+### Enhancements
+
+- [Enhancement 1]
+- [Enhancement 2]
+- [Enhancement 3]
+
+### Bug Fixes
+
+- [Bug Fix 1]
+- [Bug Fix 2]
+- [Bug Fix 3]
+
+### Breaking Changes
+
+- [Breaking Change 1]
+- [Breaking Change 2]
+- [Breaking Change 3]
+
+### Dependencies
+
+- [Dependency 1]
+- [Dependency 2]
+- [Dependency 3]
+
+### Contributors
+
+Thank you to the following contributors for their contributions to this release:
+
+- [Contributor 1]
+- [Contributor 2]
+- [Contributor 3]
+
+### Changelog
+
+Please check the [Changelog](../../CHANGELOG.md) for a detailed list of changes.
+
+### Installation
+
+You can install or upgrade to this version using [Package Manager Name]:
+
+```sh
+[Package Manager Command to Install/Upgrade]
+```
+
+### Documentation
+
+For more detailed information, check the Documentation.
+
+### Support
+
+If you encounter any issues or need assistance, please create an issue here.
+
+### License
+
+This project is licensed under [License Name]. Please see the LICENSE file for more details.


### PR DESCRIPTION
## Pull Request

### Description
This pull request adds a GitHub release template in Markdown. The template is designed to help standardize the release notes for the project, making it easier for users to understand the changes introduced in each release.

### Related Issue(s)
None

### Changes Made
- Added a Markdown template for creating new GitHub releases.
- Included sections for new features, enhancements, bug fixes, breaking changes, dependencies, contributors, changelog, installation, documentation, support, and license information.

### Testing Done
To validate the changes, the following testing was performed:
- The template was used to create a sample release to ensure it is working as expected.
- Checked for formatting issues and ensured the template renders correctly on GitHub.

### Screenshots (if applicable)
N/A

### Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [x] The changes have been tested thoroughly.
- [x] Documentation has been updated.
- [x] All tests pass successfully.
- [x] There are no unresolved merge conflicts.
- [x] The commit history is clean and focused.

### Additional Notes
The addition of this release template will improve the project's documentation and enhance the clarity of each release. Please review and provide feedback on any improvements that could be made. Thank you!